### PR TITLE
Fix PropForm styles

### DIFF
--- a/plugins/react/frontend/components/PropForm/index.js
+++ b/plugins/react/frontend/components/PropForm/index.js
@@ -9,7 +9,7 @@ import RightColumn from '../form/Grid/RightColumn';
 
 function PropForm(props) {
   return (
-    <div style={{ width: '70%' }}>
+    <div style={{ width: '100%' }}>
       <Grid>
         <Row>
           <LeftColumn>

--- a/plugins/react/frontend/components/form/ComboBox/styles.css
+++ b/plugins/react/frontend/components/form/ComboBox/styles.css
@@ -12,6 +12,7 @@
   padding: 6px 0;
   margin: 0;
   position: absolute;
+  left: 0;
   width: 100%;
   z-index: 10000;
   box-sizing: border-box;

--- a/plugins/react/frontend/components/form/Dropdown/styles.css
+++ b/plugins/react/frontend/components/form/Dropdown/styles.css
@@ -2,6 +2,7 @@
   border: 1px solid #eee;
   margin-top: 2em;
   top: 0;
+  left: 0;
   position: absolute;
   background: #FDFDFD;
   border-radius: 0.2em;

--- a/plugins/react/frontend/components/form/Grid/LeftColumn/styles.css
+++ b/plugins/react/frontend/components/form/Grid/LeftColumn/styles.css
@@ -1,6 +1,6 @@
 .root {
   box-sizing: border-box;
-  width: 38%;
+  width: 39%;
   padding-left: 1rem;
   /* background is useful for css debugging */
   /*background-color: #bde2d7;*/

--- a/plugins/react/frontend/components/form/Grid/RightColumn/styles.css
+++ b/plugins/react/frontend/components/form/Grid/RightColumn/styles.css
@@ -1,6 +1,6 @@
 .root {
   box-sizing: border-box;
-  width: 62%;
+  width: 61%;
   /* background is useful for css debugging */
   /*background: #d2d2f5;*/
   float: right;

--- a/plugins/react/frontend/components/form/Grid/styles.css
+++ b/plugins/react/frontend/components/form/Grid/styles.css
@@ -28,6 +28,7 @@
 .content {
   box-sizing: border-box;
   z-index: 1;
+  padding: 0 1em 0 0;
   width: 100%;
   height: 100%;
   overflow-y: scroll;


### PR DESCRIPTION
The problem(s):
- Form bleeding into right edge of form due to `scroll-y` requirement of container.
![Form Bleed](http://i.imgur.com/7PoV64R.png "Form Bleeding")
- Dropdown & ComboBox offset by their widths, forcing the user to scroll if they want to set a prop val to null or undefined.
![Dropdown offset after scroll](http://i.imgur.com/boyH2VF.png "Dropdown offset after scroll")
![Dropdown offset](http://i.imgur.com/of8fJ6R.png "Dropdown offset")

Minor fixes in the styles to fix these. 

