### PR TITLE
fix source plugin export

### DIFF
--- a/plugins/source/plugin.js
+++ b/plugins/source/plugin.js
@@ -18,4 +18,4 @@ SourcePlugin.prototype.apply = function apply(compiler) {
   });
 };
 
-export default SourcePlugin;
+module.exports = SourcePlugin;


### PR DESCRIPTION
I have to access to `default` property

```js
const SourcePlugin = require('carte-blanche-source-plugin').default;
```