### PR TITLE
Look for components starting with a capital letter

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ You can specify some options for the webpack plugin:
     ]
   ```
 
-- `filter` (default: matches uppercase files and uppercase folders with an index file): Regex that matches your components in the `componentRoot` folder. *We do not recommend changing this, as it might have unintended side effects.*
+- `filter` (default: matches files that start with a capital letter and/or folders that start with a capital letter and contain an index file): Regex that matches your components in the `componentRoot` folder. *We do not recommend changing this, as it might have unintended side effects.*
 
   ```JS
     plugins: [

--- a/webpack-plugin/src/validateOptions.js
+++ b/webpack-plugin/src/validateOptions.js
@@ -7,7 +7,7 @@ function validateOptions(options) {
   // Remove a prefixed slash from the dest option, i.e. /test/ -> test/
   options.dest = options.dest.replace(/^\/|\\/gi, '');
   // HACK: Webpack can embed this regex verbatim and the .? makes it not insert a comment terminator
-  options.filter = options.filter || /([A-Z][a-zA-Z]*.?\/index|[A-Z][a-zA-Z]*)\.(jsx?|es6|react\.jsx?)$/;
+  options.filter = options.filter || /(\/[A-Z][a-zA-Z]*.?\/index|\/[A-Z][a-zA-Z]*)\.(jsx?|es6|react\.jsx?)$/;
 
   // Assert that the componentRoot option was specified
   if (!options.componentRoot) {


### PR DESCRIPTION
Currently the component filter will match a file that contains a capital letter. This matches files such as
`allReducers.js`

Updated so that the file and/or directory needs to start with capital letter. eg, `Button.js` or `Button/index.js`

Tested the base cases - not sure of the impact on the system of requiring a leading forward slash. Seems ok.