### PR TITLE
CommonsChunkPlugin support

### DIFF
--- a/examples/commons/src/components/Button/index.js
+++ b/examples/commons/src/components/Button/index.js
@@ -1,0 +1,17 @@
+import React, { PropTypes } from 'react';
+
+import styles from './styles';
+
+const Button = (props) => (
+  <button
+    style={(props.type === 'secondary') ? styles.button : styles.buttonPrimary}
+    {...props}
+  />
+);
+
+Button.propTypes = {
+  children: PropTypes.node.isRequired,
+  type: PropTypes.oneOf(['primary', 'secondary']),
+};
+
+export default Button;

--- a/examples/commons/src/components/Button/styles.js
+++ b/examples/commons/src/components/Button/styles.js
@@ -1,0 +1,22 @@
+const baseStyles = {
+  padding: '0.5em 1.75em',
+  fontSize: '0.75em',
+  borderRadius: '3px',
+};
+
+const styles = {
+  button: {
+    ...baseStyles,
+    border: '1px solid #6CC0E5',
+    color: '#6CC0E5',
+    backgroundColor: 'white',
+  },
+  buttonPrimary: {
+    ...baseStyles,
+    backgroundColor: '#6CC0E5',
+    color: 'white',
+    border: '1px solid #6CC0E5',
+  },
+};
+
+export default styles;

--- a/examples/commons/src/components/Profile/index.js
+++ b/examples/commons/src/components/Profile/index.js
@@ -1,0 +1,47 @@
+import React, { Component } from 'react';
+
+import Button from '../Button';
+
+import styles from './styles';
+
+class Profile extends Component {
+  static propTypes = {
+    avatarUrl: React.PropTypes.string.isRequired,
+    firstName: React.PropTypes.string.isRequired,
+    lastName: React.PropTypes.string,
+    username: React.PropTypes.string.isRequired,
+    bio: React.PropTypes.string,
+  };
+
+  onAddFriend = () => {
+    alert(`Add @${this.props.username} as a friend`); // eslint-disable-line no-alert
+  };
+
+  render() {
+    return (
+      <div style={styles.card}>
+        <div style={styles.row}>
+          <img
+            style={styles.avatar}
+            src={this.props.avatarUrl}
+            alt={`${this.props.firstName} ${this.props.lastName}`}
+          />
+          <div style={styles.information}>
+            <h1 style={styles.name}>
+              {this.props.firstName}{(this.props.lastName) ? (` ${this.props.lastName}`) : null}
+            </h1>
+            <h2 style={styles.username}>@{this.props.username}</h2>
+          </div>
+        </div>
+        <p style={styles.paragraph}>{this.props.bio}</p>
+        <div style={styles.buttonWrapper}>
+          <Button type="secondary" onClick={this.onAddFriend}>
+            Add friend!
+          </Button>
+        </div>
+      </div>
+    );
+  }
+}
+
+export default Profile;

--- a/examples/commons/src/components/Profile/styles.js
+++ b/examples/commons/src/components/Profile/styles.js
@@ -1,0 +1,57 @@
+const borderRadius = '3px';
+const fontFamily = 'Helvetica, Arial, sans-serif';
+
+const styles = {
+  card: {
+    backgroundColor: 'white',
+    borderRadius,
+    boxShadow: '0 1px 1px rgba(50,59,67,0.1)',
+    padding: '1.5em',
+    fontFamily,
+    color: '#222',
+    maxWidth: '20em',
+  },
+  row: {
+    width: '100%',
+    display: 'flex',
+    flexDirection: 'row',
+  },
+  avatar: {
+    borderRadius,
+    height: '6em',
+    width: '6em',
+  },
+  information: {
+    paddingLeft: '1.5em',
+    display: 'flex',
+    flexDirection: 'column',
+    justifyContent: 'center',
+  },
+  name: {
+    fontSize: '1.5em',
+    fontFamily,
+    margin: 0,
+    color: '#222',
+  },
+  username: {
+    fontSize: '1em',
+    fontFamily,
+    fontWeight: 300,
+    margin: 0,
+    color: '#999',
+  },
+  paragraph: {
+    fontSize: '1em',
+    margin: '1.25em 0',
+    fontFamily,
+    color: '#222',
+  },
+  buttonWrapper: {
+    display: 'flex',
+    width: '100%',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+};
+
+export default styles;

--- a/examples/commons/src/index.html
+++ b/examples/commons/src/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8">
+    <title>CarteBlanche</title>
+  </head>
+  <body>
+    <div id='root'></div>
+  </body>
+</html>

--- a/examples/commons/src/index.js
+++ b/examples/commons/src/index.js
@@ -1,0 +1,30 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+
+import Profile from './components/Profile';
+import styles from './styles';
+
+ReactDOM.render(
+  <div style={styles.wrapper}>
+    <style>{`
+      html,
+      body,
+      #root {
+        width: 100%;
+        height: 100%;
+        background-color: #f4f7f9;
+        overflow: hidden;
+        margin: 0;
+        padding: 0;
+      }
+    `}</style>
+    <Profile
+      avatarUrl="https://pbs.twimg.com/profile_images/681114454029942784/PwhopfmU.jpg"
+      firstName="Max"
+      lastName="Stoiber"
+      username="mxstbr"
+      bio="I travel around the world, brew coffee, ski mountains and make stuff on the web. Open source developer advocate (@KeystoneJS @ElementalUI), part of @reactvienna." // eslint-disable-line max-len
+    />
+  </div>,
+  document.getElementById('root')
+);

--- a/examples/commons/src/styles.js
+++ b/examples/commons/src/styles.js
@@ -1,0 +1,11 @@
+const styles = {
+  wrapper: {
+    display: 'flex',
+    justifyContent: 'center',
+    alignItems: 'center',
+    width: '100%',
+    height: '100%',
+  },
+};
+
+export default styles;

--- a/examples/commons/webpack.dev.babel.js
+++ b/examples/commons/webpack.dev.babel.js
@@ -1,0 +1,78 @@
+import path from 'path';
+import webpack from 'webpack';
+import HtmlWebpackPlugin from 'html-webpack-plugin';
+import CarteBlanche from '../../webpack-plugin/index';
+import autoprefixer from 'autoprefixer';
+
+export default {
+  devtool: 'inline-source-map',
+  output: {
+    path: path.join(__dirname, '../dist'),
+    filename: 'bundle.js',
+    publicPath: '/',
+  },
+  entry: [
+    'webpack-dev-server/client',
+    'webpack/hot/only-dev-server',
+    path.join(__dirname, './src/index.js'),
+  ],
+  plugins: [
+    // new webpack.HotModuleReplacementPlugin(),
+    new webpack.NoErrorsPlugin(),
+    new webpack.DefinePlugin({
+      'process.env': {
+        DISABLE_LOGGER: process.env.DISABLE_LOGGER,
+      },
+    }),
+    new HtmlWebpackPlugin({
+      inject: true,
+      template: path.join(__dirname, './src/index.html'),
+    }),
+    new webpack.optimize.CommonsChunkPlugin({
+      name: 'commons',
+      filename: 'commons.js',
+    }),
+    new CarteBlanche({
+      componentRoot: 'src/components',
+    }),
+  ],
+  module: {
+    loaders: [
+      {
+        test: /\.js$/,
+        loaders: ['react-hot', 'babel'],
+        exclude: /node_modules/,
+      }, {
+        test: /\.css/,
+        loader: 'style!css?modules&importLoaders=1&localIdentName=[local]__[path][name]__[hash:base64:5]!postcss-loader', // eslint-disable-line max-len
+      }, {
+        test: /\.(png|jpg|gif)$/,
+        loaders: ['url?limit=10000'],
+      }, {
+        test: /\.(svg)$/,
+        loaders: ['url?limit=0'],
+      }, {
+        test: /\.(json)$/,
+        loader: 'json',
+      },
+    ],
+  },
+  postcss: [autoprefixer({ browsers: ['last 2 versions'] })],
+  devServer: {
+    // It suppress error shown in console, so it has to be set to false.
+    quiet: false,
+    // It suppress everything except error, so it has to be set to false as well
+    // to see success build.
+    noInfo: false,
+    stats: {
+      // Config for minimal console.log mess.
+      assets: false,
+      colors: true,
+      version: false,
+      hash: false,
+      timings: false,
+      chunks: false,
+      chunkModules: false,
+    },
+  },
+};

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "example:radium": "npm run server -- --context examples/styling/radium/ --config examples/styling/radium/webpack.dev.babel.js",
     "example:jss": "npm run server -- --context examples/styling/jss/ --config examples/styling/jss/webpack.dev.babel.js",
     "example:aphrodite": "npm run server -- --context examples/styling/aphrodite/ --config examples/styling/aphrodite/webpack.dev.babel.js",
+    "example:commons": "npm run server -- --context examples/commons/ --config examples/commons/webpack.dev.babel.js",
     "example:redux:todomvc": "npm run server -- --context examples/redux/todomvc/ --config examples/redux/todomvc/webpack.config.babel.js",
     "formEnvironment": "npm run server -- --context plugins/react/formEnvironment/ --config plugins/react/formEnvironment/webpack.dev.babel.js",
     "client:dev": "webpack-dev-server --hot --config client/webpack.dev.babel.js",

--- a/plugins/react/frontend/components/PlaygroundList/index.js
+++ b/plugins/react/frontend/components/PlaygroundList/index.js
@@ -441,6 +441,7 @@ class PlaygroundList extends Component {
               <Playground
                 userFiles={this.props.userFiles}
                 dest={this.props.dest}
+                commonsChunkFilename={this.props.commonsChunkFilename}
                 injectTags={this.props.injectTags}
                 component={component}
                 componentPath={this.props.componentPath}
@@ -478,6 +479,7 @@ class PlaygroundList extends Component {
             <Playground
               userFiles={this.props.userFiles}
               dest={this.props.dest}
+              commonsChunkFilename={this.props.commonsChunkFilename}
               injectTags={this.props.injectTags}
               key={variationPath}
               variationPath={variationPath}
@@ -489,6 +491,7 @@ class PlaygroundList extends Component {
             <Playground
               userFiles={this.props.userFiles}
               dest={this.props.dest}
+              commonsChunkFilename={this.props.commonsChunkFilename}
               injectTags={this.props.injectTags}
               key={variationPath}
               component={component}

--- a/plugins/react/frontend/components/common/IFrame/index.js
+++ b/plugins/react/frontend/components/common/IFrame/index.js
@@ -4,7 +4,7 @@
 import React from 'react';
 import path from 'path';
 
-const createHtml = (componentPath, dest, userFiles, injectTags) => (
+const createHtml = (componentPath, dest, userFiles, injectTags, commonsChunkFilename) => (
   `<!DOCTYPE html>
   <html style="height: 100%; width: 100%; margin: 0; padding: 0;">
     <head>
@@ -27,6 +27,7 @@ const createHtml = (componentPath, dest, userFiles, injectTags) => (
         window.COMPONENT_PATH = '${componentPath}';
         window.COMPONENT_DATA = undefined;
       </script>
+      ${(commonsChunkFilename) ? `<script src="/${commonsChunkFilename}"></script>` : ''}
       <script>
         ${userFiles && userFiles.scripts.join('\n')}
       </script>
@@ -43,7 +44,7 @@ class IFrame extends React.Component {
     const doc = this.iframe.contentDocument;
     doc.open();
     // eslint-disable-next-line max-len
-    doc.write(createHtml(this.props.componentPath, this.props.dest, this.props.userFiles, this.props.injectTags));
+    doc.write(createHtml(this.props.componentPath, this.props.dest, this.props.userFiles, this.props.injectTags, this.props.commonsChunkFilename));
     doc.close();
 
     this.iframe.contentWindow.INITIAL_COMPONENT_DATA = this.props.variationProps;

--- a/plugins/react/frontend/components/common/Playground/index.js
+++ b/plugins/react/frontend/components/common/Playground/index.js
@@ -156,6 +156,7 @@ class Playground extends React.Component {
             ) : (
               <IFrame
                 dest={this.props.dest}
+                commonsChunkFilename={this.props.commonsChunkFilename}
                 variationProps={this.props.variationProps}
                 userFiles={this.props.userFiles}
                 injectTags={this.props.injectTags}

--- a/plugins/react/frontend/index.js
+++ b/plugins/react/frontend/index.js
@@ -22,6 +22,7 @@ export default function playground(
       hostname={options.hostname}
       port={options.port}
       dest={JSON.parse(pluginData.dest)}
+      commonsChunkFilename={JSON.parse(pluginData.commonsChunkFilename)}
       userFiles={frontendData.files}
       injectTags={options.injectTags}
       componentPath={componentPath}

--- a/webpack-plugin/src/apply.js
+++ b/webpack-plugin/src/apply.js
@@ -92,10 +92,7 @@ function apply(compiler) {
   // The client assets, default the HTML to only include the client bundles and the
   // user bundle
   const clientAssets = {
-    'index.html': createHTML({
-      dest,
-      commonsChunkFilename,
-    }),
+    'index.html': createHTML({ dest, commonsChunkFilename }),
     'client-bundle.js': fs.readFileSync(path.resolve(__dirname, './assets/client-bundle.js')),
     'client-bundle.css': fs.readFileSync(path.resolve(__dirname, './assets/main.css')),
   };

--- a/webpack-plugin/src/dynamic-resolve.js
+++ b/webpack-plugin/src/dynamic-resolve.js
@@ -12,7 +12,7 @@ module.exports = function dynamicResolve() {
 
   const loaderMapping = {
     compiledComponent: '',
-    meta: `!!${require.resolve('./loaders/plugins-loader.js')}?dest="${query.dest}"!`,
+    meta: `!!${require.resolve('./loaders/plugins-loader.js')}?dest="${query.dest}"&commonsChunkFilename="${query.commonsChunkFilename}"!`,
     examples: `${require.resolve('./loaders/examples-loader.js')}!`,
   };
 

--- a/webpack-plugin/src/loaders/plugins-loader.js
+++ b/webpack-plugin/src/loaders/plugins-loader.js
@@ -35,7 +35,7 @@ module.exports = function pluginsLoader(source) {
   }
 
    // Pass the source code of the component to the plugins
-  const pluginData = { source, dest: query.dest };
+  const pluginData = { source, dest: query.dest, commonsChunkFilename: query.commonsChunkFilename };
 
   // Trigger events for carte-blanche child plugins
   this._compilation.applyPlugins( // eslint-disable-line no-underscore-dangle

--- a/webpack-plugin/src/utils/__test__/constructorIndexInArray.js
+++ b/webpack-plugin/src/utils/__test__/constructorIndexInArray.js
@@ -1,0 +1,53 @@
+/* eslint-disable no-unused-expressions */
+import { expect } from 'chai';
+import constructorIndexInArray from '../constructorIndexInArray';
+
+describe('constructorIndexInArray', () => {
+  it('should find normal function declarations', () => {
+    function CommonsChunkPlugin() {}
+    const array = [
+      new CommonsChunkPlugin(),
+    ];
+    expect(constructorIndexInArray(array, 'CommonsChunkPlugin')).to.equal(0);
+  });
+
+  it('should find it, not depending on the options passed', () => {
+    function CommonsChunkPlugin() {}
+    const array = [
+      new CommonsChunkPlugin({
+        some: 'options',
+      }),
+    ];
+    expect(constructorIndexInArray(array, 'CommonsChunkPlugin')).to.equal(0);
+  });
+
+  it('should find it at other places than the first', () => {
+    function SomeOtherPlugin() {}
+    function CommonsChunkPlugin() {}
+    const array = [
+      new SomeOtherPlugin(),
+      new CommonsChunkPlugin(),
+    ];
+    expect(constructorIndexInArray(array, 'CommonsChunkPlugin')).to.equal(1);
+  });
+
+  it('should find ES6 arrow functions', () => {
+    const CommonsChunkPlugin = () => {};
+    const array = [
+      new CommonsChunkPlugin(),
+    ];
+    expect(constructorIndexInArray(array, 'CommonsChunkPlugin')).to.equal(0);
+  });
+
+  it('should throw if the first argument is not an array', () => {
+    expect(constructorIndexInArray).to.throw(/The first argument must be an array/);
+  });
+
+  it('should not find non-instantiated classes', () => {
+    const CommonsChunkPlugin = () => {};
+    const array = [
+      CommonsChunkPlugin(),
+    ];
+    expect(constructorIndexInArray(array, 'CommonsChunkPlugin')).to.be.false;
+  });
+});

--- a/webpack-plugin/src/utils/__test__/createHTML.js
+++ b/webpack-plugin/src/utils/__test__/createHTML.js
@@ -41,11 +41,11 @@ describe('createHTML', () => {
     <script src="/examples/user-bundle.js"></script>
   </body>
 </html>`;
-    expect(createHTML(dest)).to.equal(expected);
+    expect(createHTML({ dest })).to.equal(expected);
   });
 
   it('should inject scripts', () => {
-    const scripts = ['console.log("Hello World!")'];
+    const extraScripts = ['console.log("Hello World!")'];
     const expected = `
 <!DOCTYPE html>
 <html>
@@ -62,11 +62,11 @@ describe('createHTML', () => {
     <script src="user-bundle.js"></script>
   </body>
 </html>`;
-    expect(createHTML(undefined, scripts)).to.equal(expected);
+    expect(createHTML({ extraScripts })).to.equal(expected);
   });
 
   it('should inject styles', () => {
-    const styles = ['body { background: red; }'];
+    const extraStyles = ['body { background: red; }'];
     const expected = `
 <!DOCTYPE html>
 <html>
@@ -83,6 +83,27 @@ describe('createHTML', () => {
     <script src="user-bundle.js"></script>
   </body>
 </html>`;
-    expect(createHTML(undefined, undefined, styles)).to.equal(expected);
+    expect(createHTML({ extraStyles })).to.equal(expected);
+  });
+
+  it('should inject the common chunk', () => {
+    const commonsChunkFilename = 'commons.js';
+    const expected = `
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8">
+    <title>CarteBlanche</title>
+    <link rel="stylesheet" type="text/css" href="client-bundle.css" />
+  </head>
+  <body>
+    <div id='carte-blanche-root'></div>
+
+    <script src="/commons.js"></script>
+    <script src="client-bundle.js"></script>
+    <script src="user-bundle.js"></script>
+  </body>
+</html>`;
+    expect(createHTML({ commonsChunkFilename })).to.equal(expected);
   });
 });

--- a/webpack-plugin/src/utils/constructorIndexInArray.js
+++ b/webpack-plugin/src/utils/constructorIndexInArray.js
@@ -1,0 +1,19 @@
+/**
+ * Check if an array contains a constructor with a certain name
+ */
+const constructorIndexInArray = (array, name) => {
+  // The first argument has to be an array
+  if (!Array.isArray(array)) {
+    // eslint-disable-next-line max-len
+    throw new Error('[CarteBlanche] constructorIndexInArray: The first argument must be an array.');
+  }
+  for (let i = 0; i < array.length; i++) {
+    // Check the constructor name of the current array element
+    if (array[i] && array[i].constructor.name === name) {
+      return i;
+    }
+  }
+  return false;
+};
+
+export default constructorIndexInArray;

--- a/webpack-plugin/src/utils/createHTML.js
+++ b/webpack-plugin/src/utils/createHTML.js
@@ -7,7 +7,7 @@ import path from 'path';
  * @param  {String} dest The URL carte-blanche should be at
  * @return {Object}      The template split into two parts
  */
-const createBaseTemplate = (dest) => ({
+const createBaseTemplate = (dest, commonsChunkFilename) => ({
   top: `
 <!DOCTYPE html>
 <html>
@@ -18,7 +18,7 @@ const createBaseTemplate = (dest) => ({
   </head>
   <body>
     <div id='carte-blanche-root'></div>\n`,
-  bottom: `
+  bottom: `${(commonsChunkFilename) ? `    <script src="/${commonsChunkFilename}"></script>` : ''}
     <script src="${(dest) ? `/${path.join(dest, 'client-bundle.js')}` : 'client-bundle.js'}"></script>
     <script src="${(dest) ? `/${path.join(dest, 'user-bundle.js')}` : 'user-bundle.js'}"></script>
   </body>
@@ -26,27 +26,32 @@ const createBaseTemplate = (dest) => ({
 });
 
 /**
- * Create HTML from a base template with injected styles and scripts
+ * Create HTML from a base template with injected styles and scripts and the
+ * common chunk
  *
- * @param  {Array} scripts An array of strings filled with JS code
- * @param  {Array} styles              --“--               CSS code
+ * @param {Object} [options]              The options
+ * @param {String} [options.dest]         The subfolder where the bundles are
+ * @param {Array}  [options.extraScripts] An array of strings filled with JS code
+ * @param {Array}  [options.extraStyles]              --“--               CSS code
+ * @param {Array}  [options.commonsChunkFilename] The common chunk filename
  *
  * @return {String}        The finished HTML
  */
-const createHTML = (dest, scripts, styles) => {
-  const baseTemplate = createBaseTemplate(dest || '');
-  // If there's no scripts or styles return the basetemplate
-  if (!scripts && !styles) {
+const createHTML = (options) => {
+  const { dest, extraScripts, extraStyles, commonsChunkFilename } = options || {};
+  const baseTemplate = createBaseTemplate(dest || '', commonsChunkFilename || '');
+  // If there's no extraScripts or extraStyles return the basetemplate
+  if (!extraScripts && !extraStyles) {
     return `${baseTemplate.top}\n${baseTemplate.bottom}`;
   }
 
   // Put together the injected content
   let injectedContent = '';
-  if (scripts) {
-    injectedContent += `    <script>${scripts.join('\n')}</script>\n`;
+  if (extraScripts) {
+    injectedContent += `    <script>${extraScripts.join('\n')}</script>\n`;
   }
-  if (styles) {
-    injectedContent += `    <style>${styles.join('\n')}</style>\n`;
+  if (extraStyles) {
+    injectedContent += `    <style>${extraStyles.join('\n')}</style>\n`;
   }
   return `${baseTemplate.top}${injectedContent}${baseTemplate.bottom}`;
 };

--- a/webpack-plugin/src/utils/getCommonsChunkFilename.js
+++ b/webpack-plugin/src/utils/getCommonsChunkFilename.js
@@ -1,0 +1,42 @@
+import constructorIndexInArray from './constructorIndexInArray';
+
+/**
+ * Get the common chunk filename from the CommonsChunkPlugin options
+ *
+ * @param  {Object} commonsChunkOptions
+ *
+ * @return {String}                     The common chunk filename
+ */
+const getCommonsChunkFilename = (pluginOptions) => {
+  // Detect CommonsChunkPlugin usage
+  const commonsChunkPluginIndex = constructorIndexInArray(
+    pluginOptions,
+    'CommonsChunkPlugin'
+  );
+
+  // Get the filename of the common chunk
+  let commonsChunkFilename;
+  if (commonsChunkPluginIndex !== false) {
+    const commonsChunkOptions = pluginOptions[commonsChunkPluginIndex];
+    // Called like "new CommonsChunkPlugin('somename')"
+    if (commonsChunkOptions.filenameTemplate ===
+        commonsChunkOptions.chunkNames) {
+      commonsChunkFilename = `${commonsChunkOptions.chunkNames}.js`;
+    // Called like "new CommonsChunkPlugin({ filename: 'somefilename.js' })"
+    } else if (commonsChunkOptions.filenameTemplate) {
+      commonsChunkFilename = commonsChunkOptions.filenameTemplate;
+    // Called like "new CommonsChunkPlugin({ name: 'somename' })"
+    } else if (commonsChunkOptions.chunkNames) {
+      commonsChunkFilename = `${commonsChunkOptions.chunkNames}.js`;
+    // Don't know if this can actually happen, better to have it there just in case
+    } else {
+      // eslint-disable-next-line no-console
+      console.log('[CarteBlanche] We detected you use the CommonsChunkPlugin, ' +
+      'but we could not detect the filename of the common chunk. Please use the ' +
+      '"filename" option of the CommonsChunkPlugin.');
+    }
+  }
+  return commonsChunkFilename;
+};
+
+export default getCommonsChunkFilename;


### PR DESCRIPTION
This PR adds implicit (!) `CommonsChunkPlugin` support and an example with the plugin enabled.

That means we auto-detect if users use it and adapt to it by including the common chunk into our HTML files. No config needed™!

:tada:

*Note: We check if users have it included by checking the constructor name in the plugins array. This means if people do something weird like `import CommonsChunkPlugin as SomethingElse` and then do `new SomethingElse()` in their plugins array, it won't work, but honestly we should discourage that anyway.*

Two small points-of-action we should do after this is merged:

- We should find a better (i.e. more scalable) way to pipe specific data from the core options to the plugins (like right now the `dest` option and the `commonsChunkFilename`), but that's for another PR.

- We should fix the iFrame HTML having `<script>undefined</script>` in them, which is an artifact from my quickly-finish-this-before-react-europe coding.