### PR TITLE
Fix prop sidebar in modal form to be full height of the window

### DIFF
--- a/plugins/react/frontend/components/common/Playground/styles.css
+++ b/plugins/react/frontend/components/common/Playground/styles.css
@@ -11,7 +11,8 @@
 .wrapper--fullHeight {
   composes: wrapper;
   border: none;
-  margin: 0 auto;
+  margin: 0 auto 20px;
+  overflow-y: scroll;
 }
 
 .card {

--- a/plugins/react/frontend/components/form/Grid/styles.css
+++ b/plugins/react/frontend/components/form/Grid/styles.css
@@ -1,8 +1,11 @@
 .root {
   display: flex;
   box-sizing: border-box;
-  position: relative;
-  height: 100%;
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 50%;
 }
 
 .leftBackgroundColumn {


### PR DESCRIPTION
When the props modal was shown, the columns wouldn't stretch to 100% height of the window. That caused dropdowns not showing properly if they were in the last row:

<img width="1181" alt="screen shot 2016-06-12 at 16 48 35" src="https://cloud.githubusercontent.com/assets/6726858/15992674/83dd4a0e-30c9-11e6-98ba-0e055621484a.png">

This fix makes both columns (props and preview) scrollable independently and sets their wrapper to fit the window.