### PR TITLE
use source of faker instead of compiled one

### DIFF
--- a/plugins/react/frontend/components/controls/advanced/AvatarControl/randomValue.js
+++ b/plugins/react/frontend/components/controls/advanced/AvatarControl/randomValue.js
@@ -1,5 +1,5 @@
 import valueOrNullOrUndefined from '../../../../utils/valueOrNullOrUndefined';
-import faker from 'faker/build/build/faker';
+import faker from 'faker';
 
 export default (props) => {
   const canBeUndefined = !props.required;

--- a/plugins/react/frontend/components/controls/advanced/IntegerControl/randomValue.js
+++ b/plugins/react/frontend/components/controls/advanced/IntegerControl/randomValue.js
@@ -1,5 +1,5 @@
 import valueOrNullOrUndefined from '../../../../utils/valueOrNullOrUndefined';
-import faker from 'faker/build/build/faker';
+import faker from 'faker';
 
 export default (props) => {
   const { required, constraints = {} } = props;

--- a/plugins/react/frontend/components/controls/advanced/NameControl/randomValue.js
+++ b/plugins/react/frontend/components/controls/advanced/NameControl/randomValue.js
@@ -1,5 +1,5 @@
 import valueOrNullOrUndefined from '../../../../utils/valueOrNullOrUndefined';
-import faker from 'faker/build/build/faker';
+import faker from 'faker';
 
 export default (props) => {
   const {

--- a/plugins/react/frontend/components/controls/advanced/PhoneControl/randomValue.js
+++ b/plugins/react/frontend/components/controls/advanced/PhoneControl/randomValue.js
@@ -1,5 +1,5 @@
 import valueOrNullOrUndefined from '../../../../utils/valueOrNullOrUndefined';
-import faker from 'faker/build/build/faker';
+import faker from 'faker';
 
 export default ({ required }) => {
   const canBeUndefined = !required;

--- a/plugins/react/frontend/components/controls/base/StringControl/randomValue.js
+++ b/plugins/react/frontend/components/controls/base/StringControl/randomValue.js
@@ -1,5 +1,5 @@
 import valueOrNullOrUndefined from '../../../../utils/valueOrNullOrUndefined';
-import faker from 'faker/build/build/faker';
+import faker from 'faker';
 
 export default (props) => {
   const canBeUndefined = !props.required;


### PR DESCRIPTION
fixes #336 

I haven't noticed any problem with my edits, the data is correctly randomized.

Tests fail with:

```
1) codeToCustomMetadata should catch errors correctly:

      AssertionError: expected { Object (err) } to deeply equal { Object (err) }
      + expected - actual

       {
      -  "err": "SyntaxError: Unexpected token u in JSON at position 26"
      +  "err": "SyntaxError: Unexpected token u"
       }

      at Assertion.assertEqual (plugins/react/node_modules/chai/lib/chai/core/assertions.js:485:19)
      at Assertion.ctx.(anonymous function) [as equal] (plugins/react/node_modules/chai/lib/chai/utils/addMethod.js:41:25)
      at Context.<anonymous> (codeToCustomMetadata.js:34:48)
```

But it fails even on master, so I don't think it's related to this PR