### PR TITLE
WIP: Windows support

### DIFF
--- a/plugins/react/package.json
+++ b/plugins/react/package.json
@@ -55,8 +55,8 @@
   },
   "scripts": {
     "build": "npm run build:frontend && npm run build:backend",
-    "build:frontend": "NODE_ENV=production webpack --config webpack.prod.babel.js",
-    "build:backend": "BABEL_DISABLE_CACHE=1 BABEL_ENV=production babel --out-dir='dist' plugin.js resolver.js server/server.js server/run.js server/utils/getAbsoluteVariationPath.js",
+    "build:frontend": "cross-env NODE_ENV=production webpack --config webpack.prod.babel.js",
+    "build:backend": "cross-env BABEL_DISABLE_CACHE=1 BABEL_ENV=production babel --out-dir=dist plugin.js resolver.js server/server.js server/run.js server/utils/getAbsoluteVariationPath.js",
     "dev": "npm run build:frontend -- --watch",
     "prepublish": "npm run build"
   },
@@ -64,6 +64,7 @@
     "autoprefixer": "^6.3.6",
     "babel-cli": "^6.9.0",
     "chai": "^3.5.0",
+    "cross-env": "^1.0.7",
     "css-loader": "^0.23.1",
     "enzyme": "^2.3.0",
     "extract-text-webpack-plugin": "^1.0.1",

--- a/plugins/react/server/utils/__test__/getAbsoluteVariationPath.js
+++ b/plugins/react/server/utils/__test__/getAbsoluteVariationPath.js
@@ -1,5 +1,6 @@
 import getAbsoluteVariationPath from '../getAbsoluteVariationPath';
 import { expect } from 'chai';
+import path from 'path';
 
 describe('getAbsoluteVariationPath', () => {
   it('should get the absolute path from the variations base path and the component path', () => {
@@ -7,7 +8,7 @@ describe('getAbsoluteVariationPath', () => {
     const componentPath = 'src/components/Button.js';
 
     expect(getAbsoluteVariationPath(variationsBasePath, componentPath)).to.equal(
-      '/User/asdf/variations/src/components/Button'
+      path.normalize('/User/asdf/variations/src/components/Button')
     );
   });
 
@@ -16,7 +17,7 @@ describe('getAbsoluteVariationPath', () => {
     const componentPath = 'src/components/Button.js';
 
     expect(getAbsoluteVariationPath(variationsBasePath, componentPath)).to.equal(
-      'src/components/Button'
+      path.normalize('src/components/Button')
     );
   });
 
@@ -25,7 +26,7 @@ describe('getAbsoluteVariationPath', () => {
     const componentPath = 'src/components/Button.js';
 
     expect(getAbsoluteVariationPath(variationsBasePath, componentPath)).to.equal(
-      'src/variations/src/components/Button'
+      path.normalize('src/variations/src/components/Button')
     );
   });
 
@@ -34,7 +35,7 @@ describe('getAbsoluteVariationPath', () => {
     const componentPath = '';
 
     expect(getAbsoluteVariationPath(variationsBasePath, componentPath)).to.equal(
-      '/User/asdf/variations'
+      path.normalize('/User/asdf/variations')
     );
   });
 
@@ -43,7 +44,7 @@ describe('getAbsoluteVariationPath', () => {
     const componentPath = '/src/components/Button.js';
 
     expect(getAbsoluteVariationPath(variationsBasePath, componentPath)).to.equal(
-      '/User/asdf/variations/src/components/Button'
+      path.normalize('/User/asdf/variations/src/components/Button')
     );
   });
 });

--- a/plugins/source/package.json
+++ b/plugins/source/package.json
@@ -33,13 +33,14 @@
     "react": "^15.0.1"
   },
   "scripts": {
-    "build": "BABEL_DISABLE_CACHE=1 BABEL_ENV=production babel --out-dir='dist' plugin.js component.js",
+    "build": "cross-env BABEL_DISABLE_CACHE=1 BABEL_ENV=production babel --out-dir=dist plugin.js component.js",
     "dev": "npm run build -- --watch",
     "prepublish": "npm run build"
   },
   "devDependencies": {
     "autoprefixer": "^6.3.6",
     "babel-cli": "^6.9.0",
+    "cross-env": "^1.0.7",
     "webpack": "^1.13.1"
   }
 }

--- a/webpack-plugin/package.json
+++ b/webpack-plugin/package.json
@@ -5,7 +5,7 @@
   "main": "dist/index.js",
   "scripts": {
     "prebuild": "rimraf ./dist/*",
-    "build": "BABEL_DISABLE_CACHE=1 BABEL_ENV=production NODE_ENV=production babel --ignore='node_modules' --out-dir='dist' . index.js && npm run copy",
+    "build": "cross-env BABEL_DISABLE_CACHE=1 BABEL_ENV=production NODE_ENV=production babel --ignore=node_modules --out-dir=dist . index.js && npm run copy",
     "copy": "ncp ./src/assets ./dist/src/assets",
     "prepublish": "npm run build"
   },
@@ -32,6 +32,7 @@
   },
   "devDependencies": {
     "babel-cli": "^6.9.0",
+    "cross-env": "^1.0.7",
     "ncp": "^2.0.0",
     "rimraf": "^2.5.2",
     "sinon": "^1.17.4"

--- a/webpack-plugin/package.json
+++ b/webpack-plugin/package.json
@@ -28,7 +28,8 @@
     "loader-utils": "^0.2.15",
     "lodash": "^4.13.1",
     "mocha": "^2.5.3",
-    "read-multiple-files": "^1.1.1"
+    "read-multiple-files": "^1.1.1",
+    "slash": "^1.0.0"
   },
   "devDependencies": {
     "babel-cli": "^6.9.0",

--- a/webpack-plugin/src/apply.js
+++ b/webpack-plugin/src/apply.js
@@ -41,7 +41,7 @@ function apply(compiler) {
   }
 
   // Compile the client
-  const userBundleFileName = path.join(this.options.dest, 'user-bundle.js');
+  const userBundleFileName = path.posix.join(this.options.dest, 'user-bundle.js');
   const userEntries = compiler.options.entry;
   const devServerOptions = compiler.options.devServer;
   const commonsChunkFilename = getCommonsChunkFilename(compiler.options.plugins);

--- a/webpack-plugin/src/dynamic-resolve.js
+++ b/webpack-plugin/src/dynamic-resolve.js
@@ -1,10 +1,7 @@
 /* eslint-disable max-len */
 import loaderUtils from 'loader-utils';
 import path from 'path';
-
-// backslashes need to be duplicated, because we loose them all otherwise
-// when turned into a string in the return statement
-const adjustBackSlashes = (p) => p.replace(/\\/g, '\\\\');
+import duplicateBackslashes from './utils/duplicateBackslashes';
 
 module.exports = function dynamicResolve() {
   this.cacheable();
@@ -23,8 +20,9 @@ module.exports = function dynamicResolve() {
   const loaders = Object.keys(loaderMapping);
 
   // Add dynamics requires for every loaders
+  // duplicate backslashes to prevent them being escaped away in returned script
   loaders.forEach((loader) => {
-    loaderMapping[loader] = `require.context('${adjustBackSlashes(loaderMapping[loader] + absoluteComponentRoot)}', true, ${filter})`;
+    loaderMapping[loader] = `require.context('${duplicateBackslashes(loaderMapping[loader] + absoluteComponentRoot)}', true, ${filter})`;
   });
 
   return `

--- a/webpack-plugin/src/dynamic-resolve.js
+++ b/webpack-plugin/src/dynamic-resolve.js
@@ -1,15 +1,15 @@
 /* eslint-disable max-len */
 import loaderUtils from 'loader-utils';
 import path from 'path';
+import slash from 'slash';
 import duplicateBackslashes from './utils/duplicateBackslashes';
 
 module.exports = function dynamicResolve() {
   this.cacheable();
   const query = loaderUtils.parseQuery(this.query);
   const filter = query.filter;
-  // TODO check on windows
   const absoluteComponentRoot = path.resolve(query.context, query.componentRoot);
-  const relativeComponentRoot = path.relative(query.context, absoluteComponentRoot);
+  const relativeComponentRoot = slash(path.relative(query.context, absoluteComponentRoot));
 
   const loaderMapping = {
     compiledComponent: '',

--- a/webpack-plugin/src/dynamic-resolve.js
+++ b/webpack-plugin/src/dynamic-resolve.js
@@ -2,6 +2,10 @@
 import loaderUtils from 'loader-utils';
 import path from 'path';
 
+// backslashes need to be duplicated, because we loose them all otherwise
+// when turned into a string in the return statement
+const adjustBackSlashes = (p) => p.replace(/\\/g, '\\\\');
+
 module.exports = function dynamicResolve() {
   this.cacheable();
   const query = loaderUtils.parseQuery(this.query);
@@ -20,7 +24,7 @@ module.exports = function dynamicResolve() {
 
   // Add dynamics requires for every loaders
   loaders.forEach((loader) => {
-    loaderMapping[loader] = `require.context('${loaderMapping[loader]}${absoluteComponentRoot}', true, ${filter})`;
+    loaderMapping[loader] = `require.context('${adjustBackSlashes(loaderMapping[loader] + absoluteComponentRoot)}', true, ${filter})`;
   });
 
   return `

--- a/webpack-plugin/src/utils/__test__/duplicateBackslashes.js
+++ b/webpack-plugin/src/utils/__test__/duplicateBackslashes.js
@@ -1,0 +1,16 @@
+/* eslint-disable no-unused-expressions */
+import { expect } from 'chai';
+import duplicateBackslashes from '../duplicateBackslashes';
+
+describe('duplicateBackslashes', () => {
+  it('should duplicate every backslash in a string', () => {
+    const str = 'c:\\repos\\cartb\\carte-blanche';
+    const result = duplicateBackslashes(str);
+    expect(result).to.equal('c:\\\\repos\\\\cartb\\\\carte-blanche');
+  });
+
+  it('should return an empty string in case no str provided', () => {
+    const result = duplicateBackslashes();
+    expect(result).to.equal('');
+  });
+});

--- a/webpack-plugin/src/utils/createHtml.js
+++ b/webpack-plugin/src/utils/createHtml.js
@@ -9,9 +9,9 @@ import path from 'path';
  * @return {Object}          The template split into two parts
  */
 const createBaseTemplate = (basePath = '', commonsChunkFilename = '') => {
-  const clientBundleJsPath = path.join(basePath, 'client-bundle.js');
-  const clientBundleCssPath = path.join(basePath, 'client-bundle.css');
-  const userBundleJsPath = path.join(basePath, 'user-bundle.js');
+  const clientBundleJsPath = path.posix.join(basePath, 'client-bundle.js');
+  const clientBundleCssPath = path.posix.join(basePath, 'client-bundle.css');
+  const userBundleJsPath = path.posix.join(basePath, 'user-bundle.js');
   return {
     top: `
 <!DOCTYPE html>

--- a/webpack-plugin/src/utils/duplicateBackslashes.js
+++ b/webpack-plugin/src/utils/duplicateBackslashes.js
@@ -1,0 +1,7 @@
+/**
+ * Duplicate every backslash found in a string
+ *
+ * @param  {String}   str
+ * @return {String}
+ */
+export default (str = '') => str.replace(/\\/g, '\\\\');

--- a/webpack-plugin/src/utils/emitAssets.js
+++ b/webpack-plugin/src/utils/emitAssets.js
@@ -15,7 +15,8 @@ function emitAssets(compilation, assets, subFolder, callback) {
   const rootPath = isString(subFolder) && subFolder || '';
   // Emit carte-blanche assets
   Object.keys(assets).forEach((filename) => {
-    compilation.assets[path.join(rootPath, filename)] = { // eslint-disable-line no-param-reassign
+    // eslint-disable-next-line no-param-reassign
+    compilation.assets[path.posix.join(rootPath, filename)] = {
       source: () => assets[filename],
       size: () => assets[filename].length,
     };

--- a/webpack-plugin/src/utils/getBasePath.js
+++ b/webpack-plugin/src/utils/getBasePath.js
@@ -3,5 +3,5 @@ import path from 'path';
 export default (compiler, pluginOptions) => {
   const publicPath = compiler.options.output.publicPath || '';
   const dest = pluginOptions.dest || '';
-  return publicPath || dest ? path.join('/', publicPath, dest) : '';
+  return publicPath || dest ? path.posix.join('/', publicPath, dest) : '';
 };


### PR DESCRIPTION
I thought I'd start looking into this a little bit and fixed some cross-env issues in npm scripts and also figured out why #290 happened. The backslashes in Windows get escaped away in `webpack-plug/src/apply.js` when building the script that's returned as a string.
I'm now able to run `npm run example:dev` without errors and `localhost:8080` loads, unfortunately at `localhost:8080/carte-blanche` i'm getting a 404 and am a little stuck as to why that might be.
I see the `basePath` used in a few places and it should maybe always have a forward slash or at least sometimes (anything that's a URL obviously). Anyone have ideas as to the next steps?
`npm run example:dev:iron` also didn't work for me, but maybe that's related. In any case i'd say that's a battle for another day.
