### PR TITLE
enable syntax highlighting for source plugin

### DIFF
--- a/examples/dev/webpack.dev.babel.js
+++ b/examples/dev/webpack.dev.babel.js
@@ -5,6 +5,7 @@ import CarteBlanche from '../../webpack-plugin/index';
 import autoprefixer from 'autoprefixer';
 
 import ReactPlugin from '../../plugins/react/dist/plugin';
+import SourcePlugin from '../../plugins/source/plugin';
 
 export default {
   devtool: 'inline-source-map',
@@ -29,6 +30,7 @@ export default {
       componentRoot: './src/components/',
       plugins: [
         new ReactPlugin(),
+        new SourcePlugin(),
       ],
     }),
   ],
@@ -46,6 +48,12 @@ export default {
           path.join(__dirname, '../../plugins'),
         ],
       }, {
+        test: /highlight.*\.css/,
+        loader: 'style!css!postcss',
+        include: [
+          path.join(__dirname, '../../plugins'),
+        ],
+      }, {
         test: /\.css/,
         loader: 'style!css?modules&importLoaders=1&localIdentName=[local]__[path][name]__[hash:base64:5]!postcss-loader', // eslint-disable-line max-len
         include: [
@@ -53,6 +61,9 @@ export default {
           path.join(__dirname, '../../webpack-plugin'),
           path.join(__dirname, '../../plugins'),
         ],
+        exclude: [
+          /highlight.*\.css/
+        ]
       }, {
         test: /\.(png|jpg|gif)$/,
         loaders: ['url?limit=10000'],

--- a/examples/dev/webpack.dev.babel.js
+++ b/examples/dev/webpack.dev.babel.js
@@ -62,8 +62,8 @@ export default {
           path.join(__dirname, '../../plugins'),
         ],
         exclude: [
-          /highlight.*\.css/
-        ]
+          /highlight.*\.css/,
+        ],
       }, {
         test: /\.(png|jpg|gif)$/,
         loaders: ['url?limit=10000'],

--- a/package.json
+++ b/package.json
@@ -119,6 +119,7 @@
     "file-loader": "^0.9.0",
     "flow-bin": "^0.27.0",
     "fs": "0.0.2",
+    "highlight.js": "^9.5.0",
     "html-loader": "^0.4.3",
     "html-webpack-plugin": "^2.19.0",
     "immutable": "^3.8.1",

--- a/plugins/source/component.js
+++ b/plugins/source/component.js
@@ -1,5 +1,14 @@
 import React from 'react';
+import hljs from 'highlight.js';
+import 'highlight.js/styles/github-gist.css';
 
 export default function sourceFrontend(frontendData, pluginData) {
-  return (<pre>{pluginData.source}</pre>);
+  const { value, language } = hljs.highlightAuto(pluginData.source);
+  return (
+    <div style={{ width: '90%', margin: 'auto' }}>
+      <pre className={"hljs " + language}
+           dangerouslySetInnerHTML={{__html: value}}
+      />
+    </div>
+  );
 }

--- a/plugins/source/component.js
+++ b/plugins/source/component.js
@@ -6,8 +6,9 @@ export default function sourceFrontend(frontendData, pluginData) {
   const { value, language } = hljs.highlightAuto(pluginData.source);
   return (
     <div style={{ width: '90%', margin: 'auto' }}>
-      <pre className={"hljs " + language}
-           dangerouslySetInnerHTML={{__html: value}}
+      <pre
+        className={`hljs ${language}`}
+        dangerouslySetInnerHTML={{ __html: value }}
       />
     </div>
   );

--- a/plugins/source/package.json
+++ b/plugins/source/package.json
@@ -34,7 +34,8 @@
   },
   "dependencies": {
     "carte-blanche": "^0.3.0",
-    "webpack": ">=1 <3 || ^2.1.0-beta",
-    "react": "^15.0.1"
+    "highlight.js": "^9.5.0",
+    "react": "^15.0.1",
+    "webpack": ">=1 <3 || ^2.1.0-beta"
   }
 }


### PR DESCRIPTION
Related Issue #300  

![screen shot 2016-07-19 at 9 27 05 am](https://cloud.githubusercontent.com/assets/551247/16957976/7ac52536-4d93-11e6-87de-513cfe89cbff.png)

This PR makes changes to the webpack config of the dev example. I have a pending PR that adds CSS Modules support to highlight.js at isagalaev/highlight.js#1234. This would remove the need to modify the webpack config for the example project. For now, the styles are global 😞 

I'm asking for review on the approach here, since it introduces global styles currently and the css-modules approach isn't merged into highlight.js
