### PR TITLE
Remove no-op babel package from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,6 @@
   "devDependencies": {
     "aphrodite": "^0.4.0",
     "axios": "^0.12.0",
-    "babel": "^6.5.2",
     "babel-cli": "^6.9.0",
     "babel-core": "^6.9.0",
     "babel-eslint": "^6.0.4",


### PR DESCRIPTION
Was checking out the project and was trying to get the examples to run when I ran into this problem:

```bash
npm install

# ... some time later

> carte-blanche-react-plugin@0.3.0 build:backend /projects/carte-blanche/plugins/react
> cross-env BABEL_DISABLE_CACHE=1 BABEL_ENV=production babel --out-dir=dist plugin.js resolver.js server/server.js server/run.js server/utils/getAbsoluteVariationPath.js

You have mistakenly installed the `babel` package, which is a no-op in Babel 6.
Babel's CLI commands have been moved from the `babel` package to the `babel-cli` package.

    npm uninstall babel
    npm install babel-cli

See http://babeljs.io/docs/usage/cli/ for setup instructions.
```

This change simply removes the `babel` package which is a no-op in Babel 6. Removing it makes the `npm install` process not error out anymore.

If this package is still needed, feel free to close the PR! Just figured I'd help fix one of the issues I ran into while trying to get up and running with the project.