### PR TITLE
Fixes for out-of-the-box example running

### DIFF
--- a/client/webpack.dev.babel.js
+++ b/client/webpack.dev.babel.js
@@ -26,8 +26,8 @@ export default {
       {
         test: /\.js$/,
         loaders: [
-          'react-hot',
-          'babel',
+          'react-hot-loader',
+          'babel-loader',
         ],
         include: path.join(__dirname),
       }, {

--- a/client/webpack.prod.babel.js
+++ b/client/webpack.prod.babel.js
@@ -26,12 +26,12 @@ export default {
     loaders: [
       {
         test: /\.js$/,
-        loaders: ['babel'],
+        loaders: ['babel-loader'],
         exclude: /node_modules/,
       }, {
         test: /\.css$/,
         loader: xt({
-          notExtractLoader: 'style-loader',
+          fallbackLoader: 'style-loader',
           loader: 'css-loader?modules&importLoaders=1!postcss-loader',
         }),
       },

--- a/examples/commons/webpack.dev.babel.js
+++ b/examples/commons/webpack.dev.babel.js
@@ -34,20 +34,20 @@ export default {
     loaders: [
       {
         test: /\.js$/,
-        loaders: ['react-hot', 'babel'],
+        loaders: ['react-hot-loader', 'babel-loader'],
         exclude: /node_modules/,
       }, {
         test: /\.css/,
-        loader: 'style!css?modules&importLoaders=1&localIdentName=[local]__[path][name]__[hash:base64:5]!postcss-loader', // eslint-disable-line max-len
+        loader: 'style-loader!css-loader?modules&importLoaders=1&localIdentName=[local]__[path][name]__[hash:base64:5]!postcss-loader', // eslint-disable-line max-len
       }, {
         test: /\.(png|jpg|gif)$/,
-        loaders: ['url?limit=10000'],
+        loaders: ['url-loader?limit=10000'],
       }, {
         test: /\.(svg)$/,
-        loaders: ['url?limit=0'],
+        loaders: ['url-loader?limit=0'],
       }, {
         test: /\.(json)$/,
-        loader: 'json',
+        loader: 'json-loader',
       },
     ],
   },

--- a/examples/dest/webpack.dev.babel.js
+++ b/examples/dest/webpack.dev.babel.js
@@ -34,7 +34,7 @@ export default {
     loaders: [
       {
         test: /\.js$/,
-        loaders: ['react-hot', 'babel'],
+        loaders: ['react-hot-loader', 'babel-loader'],
         exclude: /node_modules/,
         // this is a hack for development
         // in the final version we compile it before shipping
@@ -55,13 +55,13 @@ export default {
         ],
       }, {
         test: /\.(png|jpg|gif)$/,
-        loaders: ['url?limit=10000'],
+        loaders: ['url-loader?limit=10000'],
       }, {
         test: /\.(svg)$/,
-        loaders: ['url?limit=0'],
+        loaders: ['url-loader?limit=0'],
       }, {
         test: /\.(json)$/,
-        loader: 'json',
+        loader: 'json-loader',
       },
     ],
   },

--- a/examples/dev/webpack.dev.babel.js
+++ b/examples/dev/webpack.dev.babel.js
@@ -35,7 +35,7 @@ export default {
     loaders: [
       {
         test: /\.js$/,
-        loaders: ['react-hot', 'babel'],
+        loaders: ['react-hot-loader', 'babel-loader'],
         exclude: /node_modules/,
         // this is a hack for development
         // in the final version we compile it before shipping
@@ -46,7 +46,7 @@ export default {
         ],
       }, {
         test: /\.css/,
-        loader: 'style!css?modules&importLoaders=1&localIdentName=[local]__[path][name]__[hash:base64:5]!postcss-loader', // eslint-disable-line max-len
+        loader: 'style-loader!css-loader?modules&importLoaders=1&localIdentName=[local]__[path][name]__[hash:base64:5]!postcss-loader', // eslint-disable-line max-len
         include: [
           path.join(__dirname, './src'),
           path.join(__dirname, '../../webpack-plugin'),
@@ -54,13 +54,13 @@ export default {
         ],
       }, {
         test: /\.(png|jpg|gif)$/,
-        loaders: ['url?limit=10000'],
+        loaders: ['url-loader?limit=10000'],
       }, {
         test: /\.(svg)$/,
-        loaders: ['url?limit=0'],
+        loaders: ['url-loader?limit=0'],
       }, {
         test: /\.(json)$/,
-        loader: 'json',
+        loader: 'json-loader',
       },
     ],
   },

--- a/examples/express/webpack.dev.babel.js
+++ b/examples/express/webpack.dev.babel.js
@@ -30,20 +30,20 @@ module.exports = {
     loaders: [
       {
         test: /\.js$/,
-        loaders: ['react-hot', 'babel'],
+        loaders: ['react-hot-loader', 'babel-loader'],
         exclude: /node_modules/,
       }, {
         test: /\.css/,
-        loader: 'style!css?modules&importLoaders=1&localIdentName=[local]__[path][name]__[hash:base64:5]!postcss-loader', // eslint-disable-line max-len
+        loader: 'style-loader!css?modules&importLoaders=1&localIdentName=[local]__[path][name]__[hash:base64:5]!postcss-loader', // eslint-disable-line max-len
       }, {
         test: /\.(png|jpg|gif)$/,
-        loaders: ['url?limit=10000'],
+        loaders: ['url-loader?limit=10000'],
       }, {
         test: /\.(svg)$/,
-        loaders: ['url?limit=0'],
+        loaders: ['url-loader?limit=0'],
       }, {
         test: /\.(json)$/,
-        loader: 'json',
+        loader: 'json-loader',
       },
     ],
   },

--- a/examples/library/webpack.config.js
+++ b/examples/library/webpack.config.js
@@ -42,7 +42,7 @@ module.exports = {
   module: {
     loaders: [{
       test: /\.jsx?$/,
-      loader: 'babel',
+      loader: 'babel-loader',
       query: {
         presets: ['es2015', 'react', 'stage-1'],
       },

--- a/examples/library/webpack.config.prod.js
+++ b/examples/library/webpack.config.prod.js
@@ -25,7 +25,7 @@ module.exports = {
   module: {
     loaders: [{
       test: /\.jsx?$/,
-      loader: 'babel',
+      loader: 'babel-loader',
       query: {
         presets: ['es2015', 'react', 'stage-1'],
       },

--- a/examples/profile/webpack.dev.babel.js
+++ b/examples/profile/webpack.dev.babel.js
@@ -28,7 +28,7 @@ export default {
     loaders: [
       {
         test: /\.js$/,
-        loaders: ['react-hot', 'babel'],
+        loaders: ['react-hot-loader', 'babel-loader'],
         exclude: /node_modules/,
       },
     ],

--- a/examples/redux/todomvc/webpack.config.babel.js
+++ b/examples/redux/todomvc/webpack.config.babel.js
@@ -37,7 +37,7 @@ module.exports = {
     loaders: [
       {
         test: /\.js$/,
-        loaders: ['babel'],
+        loaders: ['babel-loader'],
         exclude: /node_modules/,
       },
       {

--- a/examples/styling/aphrodite/webpack.dev.babel.js
+++ b/examples/styling/aphrodite/webpack.dev.babel.js
@@ -37,20 +37,20 @@ export default {
     loaders: [
       {
         test: /\.js$/,
-        loaders: ['react-hot', 'babel'],
+        loaders: ['react-hot-loader', 'babel-loader'],
         exclude: /node_modules/,
       }, {
         test: /\.css/,
-        loader: 'style!css?modules&importLoaders=1&localIdentName=[local]__[path][name]__[hash:base64:5]!postcss-loader', // eslint-disable-line max-len
+        loader: 'style-loader!css-loader?modules&importLoaders=1&localIdentName=[local]__[path][name]__[hash:base64:5]!postcss-loader', // eslint-disable-line max-len
       }, {
         test: /\.(png|jpg|gif)$/,
-        loaders: ['url?limit=10000'],
+        loaders: ['url-loader?limit=10000'],
       }, {
         test: /\.(svg)$/,
-        loaders: ['url?limit=0'],
+        loaders: ['url-loader?limit=0'],
       }, {
         test: /\.(json)$/,
-        loader: 'json',
+        loader: 'json-loader',
       },
     ],
   },

--- a/examples/styling/jss/webpack.dev.babel.js
+++ b/examples/styling/jss/webpack.dev.babel.js
@@ -37,20 +37,20 @@ export default {
     loaders: [
       {
         test: /\.js$/,
-        loaders: ['react-hot', 'babel'],
+        loaders: ['react-hot-loader', 'babel-loader'],
         exclude: /node_modules/,
       }, {
         test: /\.css/,
-        loader: 'style!css?modules&importLoaders=1&localIdentName=[local]__[path][name]__[hash:base64:5]!postcss-loader', // eslint-disable-line max-len
+        loader: 'style-loader!css-loader?modules&importLoaders=1&localIdentName=[local]__[path][name]__[hash:base64:5]!postcss-loader', // eslint-disable-line max-len
       }, {
         test: /\.(png|jpg|gif)$/,
-        loaders: ['url?limit=10000'],
+        loaders: ['url-loader?limit=10000'],
       }, {
         test: /\.(svg)$/,
-        loaders: ['url?limit=0'],
+        loaders: ['url-loader?limit=0'],
       }, {
         test: /\.(json)$/,
-        loader: 'json',
+        loader: 'json-loader',
       },
     ],
   },

--- a/examples/styling/radium/webpack.dev.babel.js
+++ b/examples/styling/radium/webpack.dev.babel.js
@@ -37,20 +37,20 @@ export default {
     loaders: [
       {
         test: /\.js$/,
-        loaders: ['react-hot', 'babel'],
+        loaders: ['react-hot-loader', 'babel-loader'],
         exclude: /node_modules/,
       }, {
         test: /\.css/,
-        loader: 'style!css?modules&importLoaders=1&localIdentName=[local]__[path][name]__[hash:base64:5]!postcss-loader', // eslint-disable-line max-len
+        loader: 'style-loader!css-loader?modules&importLoaders=1&localIdentName=[local]__[path][name]__[hash:base64:5]!postcss-loader', // eslint-disable-line max-len
       }, {
         test: /\.(png|jpg|gif)$/,
-        loaders: ['url?limit=10000'],
+        loaders: ['url-loader?limit=10000'],
       }, {
         test: /\.(svg)$/,
-        loaders: ['url?limit=0'],
+        loaders: ['url-loader?limit=0'],
       }, {
         test: /\.(json)$/,
-        loader: 'json',
+        loader: 'json-loader',
       },
     ],
   },

--- a/examples/users/webpack.dev.babel.js
+++ b/examples/users/webpack.dev.babel.js
@@ -37,20 +37,20 @@ export default {
     loaders: [
       {
         test: /\.js$/,
-        loaders: ['react-hot', 'babel'],
+        loaders: ['react-hot-loader', 'babel-loader'],
         exclude: /node_modules/,
       }, {
         test: /\.css/,
-        loader: 'style!css?modules&importLoaders=1&localIdentName=[local]__[path][name]__[hash:base64:5]!postcss-loader', // eslint-disable-line max-len
+        loader: 'style-loader!css?modules&importLoaders=1&localIdentName=[local]__[path][name]__[hash:base64:5]!postcss-loader', // eslint-disable-line max-len
       }, {
         test: /\.(png|jpg|gif)$/,
-        loaders: ['url?limit=10000'],
+        loaders: ['url-loader?limit=10000'],
       }, {
         test: /\.(svg)$/,
-        loaders: ['url?limit=0'],
+        loaders: ['url-loader?limit=0'],
       }, {
         test: /\.(json)$/,
-        loader: 'json',
+        loader: 'json-loader',
       },
     ],
   },

--- a/plugins/react/package.json
+++ b/plugins/react/package.json
@@ -57,5 +57,9 @@
     "build:backend": "cross-env BABEL_DISABLE_CACHE=1 BABEL_ENV=production babel --out-dir=dist plugin.js resolver.js server/server.js server/run.js server/utils/getAbsoluteVariationPath.js",
     "dev": "npm run build:frontend -- --watch",
     "prepublish": "npm run build"
+  },
+  "devDependencies": {
+    "babel-cli": "^6.23.0",
+    "cross-env": "^3.1.4"
   }
 }

--- a/plugins/react/webpack.prod.babel.js
+++ b/plugins/react/webpack.prod.babel.js
@@ -17,7 +17,7 @@ module.exports = {
     loaders: [
       {
         test: /\.js$/,
-        loader: 'babel',
+        loader: 'babel-loader',
       },
       {
         test: /\.css$/,

--- a/plugins/source/package.json
+++ b/plugins/source/package.json
@@ -34,7 +34,11 @@
   },
   "dependencies": {
     "carte-blanche": "^0.3.0",
-    "webpack": ">=1 <3 || ^2.1.0-beta",
-    "react": "^15.0.1"
+    "react": "^15.0.1",
+    "webpack": ">=1 <3 || ^2.1.0-beta"
+  },
+  "devDependencies": {
+    "babel-cli": "^6.23.0",
+    "cross-env": "^3.1.4"
   }
 }

--- a/plugins/source/webpack.prod.babel.js
+++ b/plugins/source/webpack.prod.babel.js
@@ -18,7 +18,7 @@ module.exports = {
     loaders: [
       {
         test: /\.js$/,
-        loader: 'babel',
+        loader: 'babel-loader',
       },
       {
         test: /\.css$/,


### PR DESCRIPTION
 - Declares missing dependencies on cross-env and babel
 - Updates webpack configs to support latest loader naming requirements